### PR TITLE
fix(address): <- allow that to work from too short a string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-algorand"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
...because before, indexing into the bytes decoded from a too short string would panic.