### PR TITLE
fix(pay-tx): <- rm minimum `amount` check from that...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-algorand"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 
 [dependencies]

--- a/src/algorand_transactions/pay_transaction.rs
+++ b/src/algorand_transactions/pay_transaction.rs
@@ -59,12 +59,12 @@ impl AlgorandTransaction {
         Ok(Self {
             note,
             sender: Some(sender),
+            amount: Some(amount),
             receiver: Some(receiver),
             genesis_hash: Some(genesis_hash),
             first_valid_round: Some(first_valid_round),
             txn_type: Some(AlgorandTransactionType::Pay),
             fee: Some(fee.check_if_satisfies_minimum_fee()?.0),
-            amount: Some(Self::check_amount_is_above_minimum(amount)?),
             last_valid_round: Some(Self::calculate_last_valid_round(
                 first_valid_round,
                 last_valid_round,


### PR DESCRIPTION
...since the minimum amount is perfectly able to be lower, for example, in transactions that are proving ownership of a given key etc.